### PR TITLE
refactor: split app into components

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,61 +1,12 @@
 <template>
-  <div v-if="!isLoggedIn">
-    <h2>ログイン</h2>
-  </div>
-  <div v-else>
-    <h2>ようこそ「{{ username }}」さん</h2>
-    <input name="newMessage" v-model="newMessage" placeholder="メッセージを入力" />
-    <button @click="sendMessage">送信</button>
-    <ul>
-      <li v-for="msg in messages" :key="msg.id">
-        {{ msg.content }} ({{ msg.created_at }})
-      </li>
-    </ul>
-  </div>
+  <Login v-if="!isLoggedIn" />
+  <Chat v-else />
 </template>
 
-<script>
-import { apiURL } from './config.js'
-import axios from 'axios'
+<script setup>
+import Chat from './components/Chat.vue'
+import Login from './components/Login.vue'
 
-export default {
-  data() {
-    return {
-      apiURL,
-      newMessage: '',
-      messages: [],
-      username: ''
-    }
-  },
-  computed: {
-    isLoggedIn() {
-      return true;
-    },
-  },
-  methods: {
-    async sendMessage() {
-      if (!this.newMessage) return
-      try {
-        await axios.post(`${this.apiURL}/message`, {
-          content: this.newMessage
-        })
-        this.newMessage = ''
-        await this.fetchMessages()
-      } catch (error) {
-        console.error('送信失敗', error)
-      }
-    },
-    async fetchMessages() {
-      try {
-        const res = await axios.get(`${this.apiURL}/messages`)
-        this.messages = res.data.messages
-      } catch (error) {
-        console.error('取得失敗', error)
-      }
-    }
-  },
-  mounted() {
-    this.fetchMessages()
-  }
-}
+const isLoggedIn = true
 </script>
+

--- a/frontend/src/components/Chat.vue
+++ b/frontend/src/components/Chat.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="chat-container">
+    <h2>ようこそ「{{ username }}」さん</h2>
+    <div class="message-input">
+      <input
+        name="newMessage"
+        v-model="newMessage"
+        placeholder="メッセージを入力"
+      />
+      <button @click="sendMessage">送信</button>
+    </div>
+    <ul class="message-list">
+      <li v-for="msg in messages" :key="msg.id">
+        {{ msg.content }}
+        <span class="date">({{ msg.created_at }})</span>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+import { apiURL } from '../config.js'
+import axios from 'axios'
+
+export default {
+  name: 'Chat',
+  data() {
+    return {
+      apiURL,
+      newMessage: '',
+      messages: [],
+      username: ''
+    }
+  },
+  methods: {
+    async sendMessage() {
+      if (!this.newMessage) return
+      try {
+        await axios.post(`${this.apiURL}/message`, {
+          content: this.newMessage
+        })
+        this.newMessage = ''
+        await this.fetchMessages()
+      } catch (error) {
+        console.error('送信失敗', error)
+      }
+    },
+    async fetchMessages() {
+      try {
+        const res = await axios.get(`${this.apiURL}/messages`)
+        this.messages = res.data.messages
+      } catch (error) {
+        console.error('取得失敗', error)
+      }
+    }
+  },
+  mounted() {
+    this.fetchMessages()
+  }
+}
+</script>
+
+<style scoped>
+.chat-container {
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 1rem;
+  background-color: #f9f9f9;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+}
+.message-input {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+.message-input input {
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.message-input button {
+  padding: 0.5rem 1rem;
+  background-color: #42b983;
+  border: none;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.message-input button:hover {
+  background-color: #369870;
+}
+.message-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.message-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #eee;
+}
+.message-list li .date {
+  color: #888;
+  font-size: 0.8rem;
+  margin-left: 0.5rem;
+}
+</style>
+

--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="login-container">
+    <h2>ログイン</h2>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Login'
+}
+</script>
+
+<style scoped>
+.login-container {
+  text-align: center;
+  margin-top: 2rem;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- Split App.vue into Login and Chat components
- Move message logic to new Chat component with improved styling
- Keep App.vue minimal with component orchestration

## Testing
- `npm test` (fails: Missing script: "test")
- `cd frontend && npm test` (fails: Missing script: "test")
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a54347133c832b8598bea985d17d4d