### PR TITLE
feat(frontend): switch to dark mode

### DIFF
--- a/frontend/src/components/Chat.vue
+++ b/frontend/src/components/Chat.vue
@@ -66,8 +66,8 @@ export default {
   max-width: 600px;
   margin: 2rem auto;
   padding: 1rem;
-  background-color: #f9f9f9;
-  border: 1px solid #ddd;
+  background-color: #1e1e1e;
+  border: 1px solid #333;
   border-radius: 8px;
 }
 .message-input {
@@ -78,8 +78,10 @@ export default {
 .message-input input {
   flex: 1;
   padding: 0.5rem;
-  border: 1px solid #ccc;
+  background-color: #2c2c2c;
+  border: 1px solid #555;
   border-radius: 4px;
+  color: #e0e0e0;
 }
 .message-input button {
   padding: 0.5rem 1rem;
@@ -99,10 +101,10 @@ export default {
 }
 .message-list li {
   padding: 0.5rem 0;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid #333;
 }
 .message-list li .date {
-  color: #888;
+  color: #aaa;
   font-size: 0.8rem;
   margin-left: 0.5rem;
 }

--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -54,6 +54,9 @@ export default {
   width: 100%;
   margin-bottom: 0.5rem;
   padding: 0.5rem;
+  background-color: #2c2c2c;
+  border: 1px solid #555;
+  color: #e0e0e0;
 }
 .login-container button {
   padding: 0.5rem 1rem;

--- a/frontend/src/components/Register.vue
+++ b/frontend/src/components/Register.vue
@@ -55,6 +55,9 @@ export default {
   width: 100%;
   margin-bottom: 0.5rem;
   padding: 0.5rem;
+  background-color: #2c2c2c;
+  border: 1px solid #555;
+  color: #e0e0e0;
 }
 .register-container button {
   padding: 0.5rem 1rem;
@@ -69,7 +72,7 @@ export default {
   cursor: pointer;
 }
 .message {
-  color: #333;
+  color: #ccc;
   margin-top: 1rem;
 }
 .error {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,7 +1,7 @@
 :root {
   font-family: system-ui, sans-serif;
-  background-color: #fff;
-  color: #000;
+  background-color: #121212;
+  color: #e0e0e0;
 }
 
 body {


### PR DESCRIPTION
## Summary
- switch global palette to dark mode
- adjust Chat, Login, and Register components for dark backgrounds and inputs

## Testing
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a684643624832ba9c9b2f3b47e5224