### PR TITLE
refactor: use options api in App

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,19 +2,40 @@
   <Chat v-if="isLoggedIn" />
   <Login
     v-else-if="!isRegisterMode"
-    @login-success="isLoggedIn = true"
-    @go-register="isRegisterMode = true"
+    @login-success="handleLoginSuccess"
+    @go-register="handleGoRegister"
   />
-  <Register v-else @go-login="isRegisterMode = false" />
+  <Register v-else @go-login="handleGoLogin" />
 </template>
 
-<script setup>
-import { ref } from 'vue'
+<script>
 import Chat from './components/Chat.vue'
 import Login from './components/Login.vue'
 import Register from './components/Register.vue'
 
-const isLoggedIn = ref(!!localStorage.getItem('token'))
-const isRegisterMode = ref(false)
+export default {
+  components: {
+    Chat,
+    Login,
+    Register,
+  },
+  data() {
+    return {
+      isLoggedIn: !!localStorage.getItem('token'),
+      isRegisterMode: false,
+    }
+  },
+  methods: {
+    handleLoginSuccess() {
+      this.isLoggedIn = true
+    },
+    handleGoRegister() {
+      this.isRegisterMode = true
+    },
+    handleGoLogin() {
+      this.isRegisterMode = false
+    },
+  },
+}
 </script>
 


### PR DESCRIPTION
## Summary
- replace `<script setup>` with Options API in `App.vue`
- move reactive auth state to `data()` and register `Chat`, `Login`, `Register` components
- implement event handlers as `methods`

## Testing
- `npm test` (fails: Missing script "test")
- `npm --prefix frontend test` (fails: Missing script "test")
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68a68810197c832b9c17e064970931bf