### PR TITLE
Improve API error handling with Japanese messages

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -14,6 +14,19 @@ app.use(bodyParser.json());
 app.use('/api', messageRoutes);
 app.use('/api/auth', authRoutes);
 
+// 未定義ルートのハンドリング
+app.use((req, res, next) => {
+  res.status(404).json({ error: 'リソースが見つかりません。' });
+});
+
+// エラーハンドリングミドルウェア
+app.use((err, req, res, next) => {
+  console.error(err);
+  const status = err.status || 500;
+  const message = err.status ? err.message : 'サーバー内部でエラーが発生しました。';
+  res.status(status).json({ error: message });
+});
+
 app.listen(port, () => {
   console.log(`サーバーが起動しました。: http://localhost:${port}`)
 });

--- a/backend/src/routes/messages.js
+++ b/backend/src/routes/messages.js
@@ -2,23 +2,35 @@ const express = require('express');
 const router = express.Router();
 const db = require('../db');
 
-router.post('/message', (req, res) => {
+router.post('/message', (req, res, next) => {
   const { content } = req.body;
-  if (!content) return res.status(400).json({ error: 'リクエストにbodyが含まれていません。' });
+  if (!content) {
+    const err = new Error('メッセージ内容は必須です。');
+    err.status = 400;
+    return next(err);
+  }
 
   const insertMessage = db.prepare('INSERT INTO messages (content) VALUES (?)');
   insertMessage.run(content, function (err) {
-    if (err) return res.status(500).json({ error: err.message });
+    if (err) {
+      const dbErr = new Error('メッセージの保存中にエラーが発生しました。');
+      dbErr.status = 500;
+      return next(dbErr);
+    }
     res.json({ success: true, id: this.lastID });
-  })
+  });
   insertMessage.finalize();
 });
 
-router.get('/messages', (req, res) => {
+router.get('/messages', (req, res, next) => {
   db.all('SELECT * FROM messages ORDER BY created_at ASC', [], (err, rows) => {
-    if (err) return res.status(500).json({ error: err.message });
+    if (err) {
+      const dbErr = new Error('メッセージの取得中にエラーが発生しました。');
+      dbErr.status = 500;
+      return next(dbErr);
+    }
     res.json({ messages: rows });
-  })
-})
+  });
+});
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- centralize backend error handling with Japanese responses
- refine message routes to forward errors and use Japanese error text

## Testing
- `cd backend && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a6928b08a4832b9eae84ce568bcdc7