### PR TITLE
Add JWT auth middleware to message routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ ChatGPTとGitHubを連携する。
 
 学習用のためセキュリティ上、本来は含めるべきでないファイル、情報が含まれている。
 
+#### 環境変数
+バックエンドでは JWT の検証に `JWT_SECRET` を使用します。`.env` などで以下のように設定してください。
+
+```
+JWT_SECRET=your_secret_key
+```
+
 #### テストアカウント
 - testUser1:password
 - testUser2:1234

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -11,8 +11,8 @@ const port = 4000;
 
 app.use(cors());
 app.use(bodyParser.json());
-app.use('/api', messageRoutes);
 app.use('/api/auth', authRoutes);
+app.use('/api', messageRoutes);
 
 // 未定義ルートのハンドリング
 app.use((req, res, next) => {

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,0 +1,18 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = (req, res, next) => {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ error: '認証が必要です' });
+  }
+
+  const token = authHeader.split(' ')[1];
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'トークンが無効です' });
+  }
+};

--- a/backend/src/routes/messages.js
+++ b/backend/src/routes/messages.js
@@ -1,8 +1,9 @@
 const express = require('express');
 const router = express.Router();
 const db = require('../db');
+const authMiddleware = require('../middleware/auth');
 
-router.post('/message', (req, res, next) => {
+router.post('/message', authMiddleware, (req, res, next) => {
   const { content } = req.body;
   if (!content) {
     const err = new Error('メッセージ内容は必須です。');
@@ -22,7 +23,7 @@ router.post('/message', (req, res, next) => {
   insertMessage.finalize();
 });
 
-router.get('/messages', (req, res, next) => {
+router.get('/messages', authMiddleware, (req, res, next) => {
   db.all('SELECT * FROM messages ORDER BY created_at ASC', [], (err, rows) => {
     if (err) {
       const dbErr = new Error('メッセージの取得中にエラーが発生しました。');


### PR DESCRIPTION
## Summary
- implement auth middleware verifying JWT from Authorization header
- apply middleware to message routes
- document JWT_SECRET environment variable

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6b4b23ca0832b9510eea98de093db