### PR TITLE
feat: add auth header to chat requests

### DIFF
--- a/frontend/src/axios.js
+++ b/frontend/src/axios.js
@@ -1,0 +1,16 @@
+import axios from 'axios'
+import { apiURL } from './config.js'
+
+const api = axios.create({
+  baseURL: apiURL
+})
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token')
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
+})
+
+export default api

--- a/frontend/src/components/Chat.vue
+++ b/frontend/src/components/Chat.vue
@@ -20,15 +20,13 @@
 </template>
 
 <script>
-import { apiURL } from '../config.js'
-import axios from 'axios'
+import api from '../axios.js'
 import userIcon from '../assets/userIcon.svg'
 
 export default {
   name: 'Chat',
   data() {
     return {
-      apiURL,
       userIcon,
       newMessage: '',
       messages: [],
@@ -44,7 +42,7 @@ export default {
       if (!this.newMessage) return;
 
       try {
-        await axios.post(`${this.apiURL}/message`, {
+        await api.post('/message', {
           content: this.newMessage
         });
         this.newMessage = '';
@@ -55,7 +53,7 @@ export default {
     },
     async fetchMessages() {
       try {
-        const res = await axios.get(`${this.apiURL}/messages`);
+        const res = await api.get('/messages');
         this.messages = res.data.messages;
       } catch (error) {
         console.error('取得失敗', error);


### PR DESCRIPTION
## Summary
- add axios instance that injects Authorization header from localStorage token
- update Chat component to use shared api client for sending and fetching messages

## Testing
- `npm test` (fails: Missing script "test")
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6bc239eec832b8fe1be617e01906f