### PR TITLE
feat(frontend): add Vuetify setup

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2,4 +2,12 @@ import { createApp } from 'vue'
 import './style.css'
 import App from './App.vue'
 
-createApp(App).mount('#app')
+import 'vuetify/styles'
+import '@mdi/font/css/materialdesignicons.css'
+import '@fontsource/roboto/400.css'
+import '@fontsource/roboto/500.css'
+import { createVuetify } from 'vuetify'
+
+const vuetify = createVuetify()
+
+createApp(App).use(vuetify).mount('#app')


### PR DESCRIPTION
## Summary
- add Vuetify, Material Design Icons, and Roboto font imports
- initialize Vuetify and use it in the Vue app before mounting

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd frontend && npm test` *(fails: Missing script: "test")*
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6cde4e454832ba76f7a9017d7d6f9