### PR TITLE
feat: enable Vuetify dark theme

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -8,6 +8,18 @@ import '@fontsource/roboto/400.css'
 import '@fontsource/roboto/500.css'
 import { createVuetify } from 'vuetify'
 
-const vuetify = createVuetify()
+const vuetify = createVuetify({
+  theme: {
+    defaultTheme: 'dark',
+    themes: {
+      dark: {
+        colors: {
+          background: '#121212',
+          'on-background': '#e0e0e0',
+        },
+      },
+    },
+  },
+})
 
 createApp(App).use(vuetify).mount('#app')

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,7 +1,5 @@
 :root {
   font-family: system-ui, sans-serif;
-  background-color: #121212;
-  color: #e0e0e0;
 }
 
 body {


### PR DESCRIPTION
## Summary
- enable Vuetify dark theme with custom background and text colors
- remove redundant background and text styles moved to Vuetify theme

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd frontend && npm test` *(fails: Missing script: "test")*
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a6d202b420832ba093bd42d4f4e5c1