### PR TITLE
feat: add top app bar with logout

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,11 +1,13 @@
 <template>
   <v-app>
+    <v-app-bar density="comfortable" elevate-on-scroll>
+      <v-app-bar-title>Web Playground</v-app-bar-title>
+      <v-spacer />
+      <v-btn v-if="isLoggedIn" color="primary" variant="text" @click="logout">ログアウト</v-btn>
+    </v-app-bar>
     <v-main>
       <v-container>
-        <div v-if="isLoggedIn">
-          <v-btn color="primary" @click="logout">ログアウト</v-btn>
-          <Chat />
-        </div>
+        <Chat v-if="isLoggedIn" />
         <Login
           v-else-if="!isRegisterMode"
           @login-success="handleLoginSuccess"


### PR DESCRIPTION
## Summary
- add top app bar with title and logout button
- organize Chat/Login/Register into main container below bar

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6d6b03228832b971284a1c53adbd2