### PR TITLE
Handle 401 responses with global Axios interceptor

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -36,6 +36,12 @@ export default {
       isRegisterMode: false,
     }
   },
+  mounted() {
+    window.addEventListener('logout', this.logout)
+  },
+  beforeUnmount() {
+    window.removeEventListener('logout', this.logout)
+  },
   methods: {
     handleLoginSuccess() {
       this.isLoggedIn = true;

--- a/frontend/src/axios.js
+++ b/frontend/src/axios.js
@@ -13,4 +13,15 @@ api.interceptors.request.use((config) => {
   return config
 })
 
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response && error.response.status === 401) {
+      localStorage.removeItem('token')
+      window.dispatchEvent(new Event('logout'))
+    }
+    return Promise.reject(error)
+  }
+)
+
 export default api


### PR DESCRIPTION
## Summary
- Clear auth token and emit logout event on 401 responses via Axios interceptor
- Listen for logout events in App component to show login screen

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68abd42d4990832b8e97dc8e7fb3f1cb