### PR TITLE
feat(frontend): add vuex store

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -24,41 +24,43 @@ import Chat from './components/Chat.vue'
 import Login from './components/Login.vue'
 import Register from './components/Register.vue'
 
-export default {
-  components: {
-    Chat,
-    Login,
-    Register,
-  },
-  data() {
-    return {
-      isLoggedIn: !!localStorage.getItem('token'),
-      isRegisterMode: false,
+  export default {
+      components: {
+        Chat,
+        Login,
+        Register,
+      },
+      computed: {
+        isLoggedIn() {
+          return this.$store.state.isLoggedIn
+        },
+        isRegisterMode() {
+          return this.$store.state.isRegisterMode
+        },
+      },
+      mounted() {
+        window.addEventListener('logout', this.logout)
+      },
+      beforeUnmount() {
+        window.removeEventListener('logout', this.logout)
+      },
+      methods: {
+        handleLoginSuccess() {
+          this.$store.commit('setLoggedIn', true);
+        },
+        handleGoRegister() {
+          this.$store.commit('setRegisterMode', true);
+        },
+        handleGoLogin() {
+          this.$store.commit('setRegisterMode', false);
+        },
+        logout() {
+          localStorage.removeItem('token');
+          localStorage.removeItem('username');
+          this.$store.commit('setLoggedIn', false);
+          this.$store.commit('setRegisterMode', false);
+        },
+      },
     }
-  },
-  mounted() {
-    window.addEventListener('logout', this.logout)
-  },
-  beforeUnmount() {
-    window.removeEventListener('logout', this.logout)
-  },
-  methods: {
-    handleLoginSuccess() {
-      this.isLoggedIn = true;
-    },
-    handleGoRegister() {
-      this.isRegisterMode = true;
-    },
-    handleGoLogin() {
-      this.isRegisterMode = false;
-    },
-    logout() {
-      localStorage.removeItem('token');
-      localStorage.removeItem('username');
-      this.isLoggedIn = false;
-      this.isRegisterMode = false;
-    },
-  },
-}
 </script>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,6 +1,7 @@
 import { createApp } from 'vue'
 import './style.css'
 import App from './App.vue'
+import store from './store'
 
 import 'vuetify/styles'
 import '@mdi/font/css/materialdesignicons.css'
@@ -24,4 +25,7 @@ const vuetify = createVuetify({
   },
 })
 
-createApp(App).use(vuetify).mount('#app')
+const app = createApp(App)
+app.use(store)
+app.use(vuetify)
+app.mount('#app')

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,0 +1,18 @@
+import { createStore } from 'vuex'
+
+export default createStore({
+  state() {
+    return {
+      isLoggedIn: !!localStorage.getItem('token'),
+      isRegisterMode: false,
+    }
+  },
+  mutations: {
+    setLoggedIn(state, value) {
+      state.isLoggedIn = value
+    },
+    setRegisterMode(state, value) {
+      state.isRegisterMode = value
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- create Vuex store managing login and registration modes
- integrate store with main app entry
- switch App component to Vuex for auth state

## Testing
- `npm test --prefix frontend` *(fails: Missing script "test")*
- `npm run build --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68ad16162268832bb7c22c95570ab0c2