### PR TITLE
feat: integrate vue router

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,32 +7,18 @@
     </v-app-bar>
     <v-main>
       <v-container>
-        <Chat v-if="isLoggedIn" />
-        <Login
-          v-else-if="!isRegisterMode"
-          @login-success="this.setLoggedIn(true)"
-          @go-register="this.setRegisterMode(true)"
-        />
-        <Register v-else @go-login="this.setRegisterMode(false)" />
+        <router-view />
       </v-container>
     </v-main>
   </v-app>
 </template>
 
 <script>
-import Chat from './components/Chat.vue'
-import Login from './components/Login.vue'
-import Register from './components/Register.vue'
 import { mapState, mapMutations } from 'vuex'
 
 export default {
-  components: {
-    Chat,
-    Login,
-    Register,
-  },
   computed: {
-    ...mapState(['isLoggedIn', 'isRegisterMode']),
+    ...mapState(['isLoggedIn']),
   },
   mounted() {
     window.addEventListener('logout', this.logout);
@@ -41,12 +27,12 @@ export default {
     window.removeEventListener('logout', this.logout);
   },
   methods: {
-    ...mapMutations(['setLoggedIn', 'setRegisterMode']),
+    ...mapMutations(['setLoggedIn']),
     logout() {
       localStorage.removeItem('token');
       localStorage.removeItem('username');
       this.setLoggedIn(false);
-      this.setRegisterMode(false);
+      this.$router.push('/');
     },
   },
 }

--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -21,7 +21,7 @@
           autocomplete="current-password"
         />
         <div class="d-flex justify-space-between">
-          <v-btn variant="text" color="primary" @click="$emit('go-register')">
+          <v-btn variant="text" color="primary" @click="goRegister">
             新規登録
           </v-btn>
           <v-btn type="submit" color="primary">
@@ -57,10 +57,14 @@ export default {
         })
         localStorage.setItem('token', res.data.token)
         localStorage.setItem('username', this.username)
-        this.$emit('login-success')
+        this.$store.commit('setLoggedIn', true)
+        this.$router.push('/chat')
       } catch (err) {
         this.error = err.response?.data?.error || 'ログインに失敗しました'
       }
+    },
+    goRegister() {
+      this.$router.push('/register')
     }
   }
 }

--- a/frontend/src/components/Register.vue
+++ b/frontend/src/components/Register.vue
@@ -21,7 +21,7 @@
           autocomplete="new-password"
         />
         <div class="d-flex justify-space-between">
-          <v-btn variant="text" color="primary" @click="$emit('go-login')">
+          <v-btn variant="text" color="primary" @click="goLogin">
             ログインへ戻る
           </v-btn>
           <v-btn type="submit" color="primary">
@@ -62,6 +62,9 @@ export default {
       } catch (err) {
         this.error = err.response?.data?.error || '登録に失敗しました';
       }
+    },
+    goLogin() {
+      this.$router.push('/')
     }
   }
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2,6 +2,7 @@ import { createApp } from 'vue'
 import './style.css'
 import App from './App.vue'
 import store from './store'
+import router from './router'
 
 import 'vuetify/styles'
 import '@mdi/font/css/materialdesignicons.css'
@@ -27,5 +28,6 @@ const vuetify = createVuetify({
 
 const app = createApp(App);
 app.use(store);
+app.use(router);
 app.use(vuetify);
 app.mount('#app');

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,0 +1,28 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import store from '../store'
+import Chat from '../components/Chat.vue'
+import Login from '../components/Login.vue'
+import Register from '../components/Register.vue'
+
+const routes = [
+  { path: '/', component: Login },
+  { path: '/register', component: Register },
+  { path: '/chat', component: Chat, meta: { requiresAuth: true } },
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes,
+})
+
+router.beforeEach((to, from, next) => {
+  if (to.meta.requiresAuth && !store.state.isLoggedIn) {
+    next('/')
+  } else if ((to.path === '/' || to.path === '/register') && store.state.isLoggedIn) {
+    next('/chat')
+  } else {
+    next()
+  }
+})
+
+export default router

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -4,15 +4,11 @@ export default createStore({
   state() {
     return {
       isLoggedIn: !!localStorage.getItem('token'),
-      isRegisterMode: false,
     }
   },
   mutations: {
     setLoggedIn(state, value) {
       state.isLoggedIn = value
-    },
-    setRegisterMode(state, value) {
-      state.isRegisterMode = value
     },
   },
 })


### PR DESCRIPTION
## Summary
- add Vue Router with routes for login, registration, and chat
- wire router into the app and navigation components
- simplify store to track only login state

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad1ad040e8832bbc8035d8bc4e2110