### PR TITLE
Set login page URL to /login

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -32,7 +32,7 @@ export default {
       localStorage.removeItem('token');
       localStorage.removeItem('username');
       this.setLoggedIn(false);
-      this.$router.push('/');
+      this.$router.push('/login');
     },
   },
 }

--- a/frontend/src/components/Register.vue
+++ b/frontend/src/components/Register.vue
@@ -64,7 +64,7 @@ export default {
       }
     },
     goLogin() {
-      this.$router.push('/')
+      this.$router.push('/login')
     }
   }
 }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -5,7 +5,7 @@ import Login from '../components/Login.vue'
 import Register from '../components/Register.vue'
 
 const routes = [
-  { path: '/', component: Login },
+  { path: '/login', component: Login },
   { path: '/register', component: Register },
   { path: '/chat', component: Chat, meta: { requiresAuth: true } },
 ]
@@ -17,8 +17,8 @@ const router = createRouter({
 
 router.beforeEach((to, from, next) => {
   if (to.meta.requiresAuth && !store.state.isLoggedIn) {
-    next('/')
-  } else if ((to.path === '/' || to.path === '/register') && store.state.isLoggedIn) {
+    next('/login')
+  } else if ((to.path === '/login' || to.path === '/register') && store.state.isLoggedIn) {
     next('/chat')
   } else {
     next()


### PR DESCRIPTION
## Summary
- route login page at /login and adjust auth guard
- update navigation in logout and register to redirect to /login

## Testing
- `npm test` (fails: Missing script "test")
- `cd frontend && npm test` (fails: Missing script "test")
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad1cfb98a8832bb73ffc795bde3a80