### PR TITLE
Add login and logout Vuex mutations

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,7 +3,7 @@
     <v-app-bar density="comfortable" elevate-on-scroll>
       <v-app-bar-title>Web Playground</v-app-bar-title>
       <v-spacer />
-      <v-btn v-if="isLoggedIn" variant="text" @click="logout">ログアウト</v-btn>
+      <v-btn v-if="isLoggedIn" variant="text" @click="handleLogout">ログアウト</v-btn>
     </v-app-bar>
     <v-main>
       <v-container>
@@ -21,18 +21,18 @@ export default {
     ...mapState(['isLoggedIn']),
   },
   mounted() {
-    window.addEventListener('logout', this.logout);
+    window.addEventListener('logout', this.handleLogout);
   },
   beforeUnmount() {
-    window.removeEventListener('logout', this.logout);
+    window.removeEventListener('logout', this.handleLogout);
   },
   methods: {
-    ...mapMutations(['setLoggedIn']),
-    logout() {
+    ...mapMutations(['logout']),
+    handleLogout() {
       localStorage.removeItem('token');
       localStorage.removeItem('username');
-      this.setLoggedIn(false);
-      this.$router.push('/');
+      this.logout();
+      this.$router.push('/login');
     },
   },
 }

--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -57,7 +57,7 @@ export default {
         })
         localStorage.setItem('token', res.data.token)
         localStorage.setItem('username', this.username)
-        this.$store.commit('setLoggedIn', true)
+        this.$store.commit('login')
         this.$router.push('/chat')
       } catch (err) {
         this.error = err.response?.data?.error || 'ログインに失敗しました'

--- a/frontend/src/components/Register.vue
+++ b/frontend/src/components/Register.vue
@@ -64,7 +64,7 @@ export default {
       }
     },
     goLogin() {
-      this.$router.push('/')
+      this.$router.push('/login')
     }
   }
 }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -5,7 +5,8 @@ import Login from '../components/Login.vue'
 import Register from '../components/Register.vue'
 
 const routes = [
-  { path: '/', component: Login },
+  { path: '/', redirect: '/login' },
+  { path: '/login', component: Login },
   { path: '/register', component: Register },
   { path: '/chat', component: Chat, meta: { requiresAuth: true } },
 ]
@@ -17,8 +18,8 @@ const router = createRouter({
 
 router.beforeEach((to, from, next) => {
   if (to.meta.requiresAuth && !store.state.isLoggedIn) {
-    next('/')
-  } else if ((to.path === '/' || to.path === '/register') && store.state.isLoggedIn) {
+    next('/login')
+  } else if ((to.path === '/login' || to.path === '/register') && store.state.isLoggedIn) {
     next('/chat')
   } else {
     next()

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -7,8 +7,11 @@ export default createStore({
     }
   },
   mutations: {
-    setLoggedIn(state, value) {
-      state.isLoggedIn = value
+    login(state) {
+      state.isLoggedIn = true
+    },
+    logout(state) {
+      state.isLoggedIn = false
     },
   },
 })


### PR DESCRIPTION
## Summary
- add dedicated `login` and `logout` mutations in the Vuex store
- update Login and App components to use the new mutations
- redirect root path to a dedicated `/login` route and update navigation accordingly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad1de376ac832ba3c3c8de0817cd17