### PR TITLE
feat: add app selection screen with dummy apps

### DIFF
--- a/frontend/src/components/AppSelection.vue
+++ b/frontend/src/components/AppSelection.vue
@@ -1,0 +1,17 @@
+<template>
+  <v-card class="mx-auto my-12" max-width="400">
+    <v-card-title>アプリを選択</v-card-title>
+    <v-card-text>
+      <v-btn block class="mb-4" @click="$router.push('/chat')">チャット</v-btn>
+      <v-btn block class="mb-4" @click="$router.push('/dummy1')">ダミーアプリ1</v-btn>
+      <v-btn block @click="$router.push('/dummy2')">ダミーアプリ2</v-btn>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script>
+export default {
+  name: 'AppSelection',
+};
+</script>
+

--- a/frontend/src/components/DummyApp1.vue
+++ b/frontend/src/components/DummyApp1.vue
@@ -1,0 +1,13 @@
+<template>
+  <v-card class="mx-auto my-12" max-width="400">
+    <v-card-title>ダミーアプリ1</v-card-title>
+    <v-card-text>ここはダミーアプリ1です。</v-card-text>
+  </v-card>
+</template>
+
+<script>
+export default {
+  name: 'DummyApp1',
+};
+</script>
+

--- a/frontend/src/components/DummyApp2.vue
+++ b/frontend/src/components/DummyApp2.vue
@@ -1,0 +1,13 @@
+<template>
+  <v-card class="mx-auto my-12" max-width="400">
+    <v-card-title>ダミーアプリ2</v-card-title>
+    <v-card-text>ここはダミーアプリ2です。</v-card-text>
+  </v-card>
+</template>
+
+<script>
+export default {
+  name: 'DummyApp2',
+};
+</script>
+

--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -58,7 +58,7 @@ export default {
         localStorage.setItem('token', res.data.token)
         localStorage.setItem('username', this.username)
         this.$store.commit('login')
-        this.$router.push('/chat')
+        this.$router.push('/apps')
       } catch (err) {
         this.error = err.response?.data?.error || 'ログインに失敗しました'
       }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -3,12 +3,18 @@ import store from '../store';
 import Chat from '../components/Chat.vue';
 import Login from '../components/Login.vue';
 import Register from '../components/Register.vue';
+import AppSelection from '../components/AppSelection.vue';
+import DummyApp1 from '../components/DummyApp1.vue';
+import DummyApp2 from '../components/DummyApp2.vue';
 
 const routes = [
   { path: '/', redirect: '/login' },
   { path: '/login', component: Login },
   { path: '/register', component: Register },
+  { path: '/apps', component: AppSelection, meta: { requiresAuth: true } },
   { path: '/chat', component: Chat, meta: { requiresAuth: true } },
+  { path: '/dummy1', component: DummyApp1, meta: { requiresAuth: true } },
+  { path: '/dummy2', component: DummyApp2, meta: { requiresAuth: true } },
 ];
 
 const router = createRouter({
@@ -20,7 +26,7 @@ router.beforeEach((to, from, next) => {
   if (to.meta.requiresAuth && !store.state.isLoggedIn) {
     next('/login');
   } else if ((to.path === '/login' || to.path === '/register') && store.state.isLoggedIn) {
-    next('/chat');
+    next('/apps');
   } else {
     next();
   }


### PR DESCRIPTION
## Summary
- add app selection page with links to chat and dummy apps
- add two dummy app pages
- redirect authenticated users to app selection

## Testing
- `npm test` (fails: Missing script "test")
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae98879044832b8cb0778f43f0cddb