### PR TITLE
Validate login and registration inputs

### DIFF
--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -50,6 +50,10 @@ export default {
   methods: {
     async login() {
       this.error = ''
+      if (!this.username || !this.password) {
+        this.error = 'ユーザー名とパスワードを入力してください'
+        return
+      }
       try {
         const res = await axios.post(`${apiURL}/auth/login`, {
           username: this.username,

--- a/frontend/src/components/Register.vue
+++ b/frontend/src/components/Register.vue
@@ -53,6 +53,10 @@ export default {
     async register() {
       this.error = '';
       this.message = '';
+      if (!this.username || !this.password) {
+        this.error = 'ユーザー名とパスワードを入力してください';
+        return;
+      }
       try {
         await axios.post(`${apiURL}/auth/register`, {
           username: this.username,


### PR DESCRIPTION
## Summary
- prevent login when username or password empty and display form error
- block registration with missing credentials and show message

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68afbdeaba10832b87c9e607728e035f