### PR TITLE
feat(frontend): open browser on serve

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,9 +7,11 @@ Vue 3 と Vite で構築したシンプルなフロントエンドです。
 ```bash
 npm install
 npm run dev
+# ブラウザを自動で開く場合
+npm run serve
 ```
 
-ブラウザで <http://localhost:5173> を開くとアプリが表示されます。
+ブラウザで <http://localhost:5173> を開くとアプリが表示されます。`npm run serve` を使用するとブラウザが自動で起動します。
 
 ## ビルド
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "serve": "vite --open",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "開発ディレクトリ\r `C:\\dev\\MyNodeSandbox`",
   "main": "index.js",
   "scripts": {
-    "start:frontend": "cd frontend && npm run dev",
+    "start:frontend": "cd frontend && npm run serve",
     "start:backend": "cd backend && npm start",
     "start:all": "concurrently \"npm run start:backend\" \"npm run start:frontend\""
   },


### PR DESCRIPTION
## Summary
- add a `serve` script to open the browser automatically via Vite
- run `serve` from `start:frontend`
- document how to launch the frontend with automatic browser opening

## Testing
- `npm test` (fails: Missing script: "test")
- `(cd frontend && npm test)` (fails: Missing script: "test")
- `(cd frontend && npm run build)`
- `(cd frontend && npm run serve)` (fails: spawn xdg-open ENOENT)


------
https://chatgpt.com/codex/tasks/task_e_68afbeac5268832bbc5b1468be092b9f