### PR TITLE
Add profile page and header navigation

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,8 +1,14 @@
 <template>
   <v-app>
     <v-app-bar density="comfortable" elevate-on-scroll>
-      <v-app-bar-title>Web Playground</v-app-bar-title>
+      <v-app-bar-title class="cursor-pointer" @click="goApps">Web Playground</v-app-bar-title>
       <v-spacer />
+      <v-btn
+        v-if="isLoggedIn"
+        variant="text"
+        class="mr-2"
+        @click="goProfile"
+      >{{ username }}</v-btn>
       <v-btn v-if="isLoggedIn" variant="text" @click="handleLogout">ログアウト</v-btn>
     </v-app-bar>
     <v-main>
@@ -18,7 +24,7 @@ import { mapState, mapMutations } from 'vuex'
 
 export default {
   computed: {
-    ...mapState(['isLoggedIn']),
+    ...mapState(['isLoggedIn', 'username']),
   },
   mounted() {
     window.addEventListener('logout', this.handleLogout);
@@ -28,6 +34,12 @@ export default {
   },
   methods: {
     ...mapMutations(['logout']),
+    goApps() {
+      this.$router.push('/apps');
+    },
+    goProfile() {
+      this.$router.push('/profile');
+    },
     handleLogout() {
       localStorage.removeItem('token');
       localStorage.removeItem('username');

--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -57,7 +57,7 @@ export default {
         })
         localStorage.setItem('token', res.data.token)
         localStorage.setItem('username', this.username)
-        this.$store.commit('login')
+        this.$store.commit('login', this.username)
         this.$router.push('/apps')
       } catch (err) {
         this.error = err.response?.data?.error || 'ログインに失敗しました'

--- a/frontend/src/components/Profile.vue
+++ b/frontend/src/components/Profile.vue
@@ -1,0 +1,19 @@
+<template>
+  <v-card class="mx-auto my-12" max-width="400">
+    <v-card-title>プロフィール</v-card-title>
+    <v-card-text>
+      ログインユーザー名: {{ username }}
+    </v-card-text>
+  </v-card>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+
+export default {
+  name: 'Profile',
+  computed: {
+    ...mapState(['username'])
+  }
+}
+</script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -6,6 +6,7 @@ import Register from '../components/Register.vue';
 import AppSelection from '../components/AppSelection.vue';
 import DummyApp1 from '../components/DummyApp1.vue';
 import DummyApp2 from '../components/DummyApp2.vue';
+import Profile from '../components/Profile.vue';
 
 const routes = [
   { path: '/', redirect: '/login' },
@@ -15,6 +16,7 @@ const routes = [
   { path: '/chat', component: Chat, meta: { requiresAuth: true } },
   { path: '/dummy1', component: DummyApp1, meta: { requiresAuth: true } },
   { path: '/dummy2', component: DummyApp2, meta: { requiresAuth: true } },
+  { path: '/profile', component: Profile, meta: { requiresAuth: true } },
 ];
 
 const router = createRouter({

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -4,14 +4,17 @@ export default createStore({
   state() {
     return {
       isLoggedIn: !!localStorage.getItem('token'),
+      username: localStorage.getItem('username') || '',
     }
   },
   mutations: {
-    login(state) {
+    login(state, username) {
       state.isLoggedIn = true;
+      state.username = username;
     },
     logout(state) {
       state.isLoggedIn = false;
+      state.username = '';
     },
   },
 })


### PR DESCRIPTION
## Summary
- make header title navigate to app selection
- show logged in username with link to profile page
- create profile page component and route

## Testing
- `npm test` (fails: Missing script: "test")
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68afbe2b4aec832b81681c4ea9d97ab7