### PR TITLE
Refactor wellbeing UI with button toggles and daily score heatmap

### DIFF
--- a/frontend/src/components/Wellbeing.vue
+++ b/frontend/src/components/Wellbeing.vue
@@ -4,14 +4,63 @@
       <v-card-title>ウェルビーイング記録</v-card-title>
       <v-card-text>
         <v-form @submit.prevent="submit">
-          <v-checkbox v-model="form.sleep_before_midnight" :true-value="1" :false-value="0" label="0時までに寝たか" />
-          <v-select v-model="form.sleep_quality" :items="sleepQualityItems" label="睡眠の質" />
-          <v-checkbox v-model="form.morning_sun" :true-value="1" :false-value="0" label="朝日（九時まで）を浴びたか" />
-          <v-checkbox v-model="form.active_exercise" :true-value="1" :false-value="0" label="10分間の能動的運動" />
-          <v-checkbox v-model="form.conversation" :true-value="1" :false-value="0" label="誰かとの会話" />
-          <v-select v-model="form.alcohol" :items="alcoholItems" label="アルコール" />
-          <v-select v-model="form.main_focus" :items="focusItems" label="今日の主軸" />
-          <v-select v-model="form.mood" :items="moodItems" label="気分" />
+          <div class="mb-2">
+            <div>0時までに寝たか</div>
+            <v-btn-toggle v-model="form.sleep_before_midnight" mandatory>
+              <v-btn :value="1">○</v-btn>
+              <v-btn :value="0">×</v-btn>
+            </v-btn-toggle>
+          </div>
+          <div class="mb-2">
+            <div>睡眠の質</div>
+            <v-btn-toggle v-model="form.sleep_quality" mandatory>
+              <v-btn :value="2">○</v-btn>
+              <v-btn :value="1">△</v-btn>
+              <v-btn :value="0">×</v-btn>
+            </v-btn-toggle>
+          </div>
+          <div class="mb-2">
+            <div>朝日（九時まで）を浴びたか</div>
+            <v-btn-toggle v-model="form.morning_sun" mandatory>
+              <v-btn :value="1">○</v-btn>
+              <v-btn :value="0">×</v-btn>
+            </v-btn-toggle>
+          </div>
+          <div class="mb-2">
+            <div>10分間の能動的運動</div>
+            <v-btn-toggle v-model="form.active_exercise" mandatory>
+              <v-btn :value="1">○</v-btn>
+              <v-btn :value="0">×</v-btn>
+            </v-btn-toggle>
+          </div>
+          <div class="mb-2">
+            <div>誰かとの会話</div>
+            <v-btn-toggle v-model="form.conversation" mandatory>
+              <v-btn :value="1">○</v-btn>
+              <v-btn :value="0">×</v-btn>
+            </v-btn-toggle>
+          </div>
+          <div class="mb-2">
+            <div>アルコール</div>
+            <v-btn-toggle v-model="form.alcohol" mandatory>
+              <v-btn :value="0">無し</v-btn>
+              <v-btn :value="-1">有り</v-btn>
+            </v-btn-toggle>
+          </div>
+          <div class="mb-2">
+            <div>今日の主軸</div>
+            <v-btn-toggle v-model="form.main_focus" mandatory>
+              <v-btn v-for="item in focusItems" :key="item" :value="item">{{ item }}</v-btn>
+            </v-btn-toggle>
+          </div>
+          <div class="mb-2">
+            <div>気分</div>
+            <v-btn-toggle v-model="form.mood" mandatory>
+              <v-btn :value="2">○</v-btn>
+              <v-btn :value="1">△</v-btn>
+              <v-btn :value="0">×</v-btn>
+            </v-btn-toggle>
+          </div>
           <v-btn type="submit" class="mt-4" block>記録</v-btn>
         </v-form>
       </v-card-text>
@@ -26,19 +75,19 @@
         <table>
           <thead>
             <tr>
-              <th>項目\日付</th>
+              <th>日付</th>
               <th v-for="d in dates" :key="d">{{ d }}</th>
             </tr>
           </thead>
           <tbody>
-            <tr v-for="metric in metrics" :key="metric.key">
-              <td>{{ metric.label }}</td>
+            <tr>
+              <td>合計点</td>
               <td
                 v-for="d in dates"
                 :key="d"
-                :style="cellStyle(metric.key, d)"
+                :style="totalCellStyle(d)"
               >
-                {{ displayValue(metric.key, d) }}
+                {{ totalPoints(d) }}
               </td>
             </tr>
           </tbody>
@@ -69,10 +118,7 @@ const form = reactive({
   mood: 0,
 });
 
-const sleepQualityItems = [0, 1, 2];
-const alcoholItems = [0, -1];
 const focusItems = ['仕事', '勉強', '家事', '運動', '休養', '創作', '交友'];
-const moodItems = [0, 1, 2];
 
 const records = ref([]);
 
@@ -135,25 +181,24 @@ const dates = computed(() => {
   return records.value.map(r => r.date).sort();
 });
 
-const cellStyle = (key, date) => {
+const totalPoints = (date) => {
   const entry = records.value.find(r => r.date === date);
-  if (!entry) return {};
-  const val = entry[key];
-  if (key === 'alcohol' && val === -1) {
-    return { background: '#ffcdd2' };
-  }
-  if (key === 'main_focus') {
-    const idx = focusItems.indexOf(val);
-    const colors = ['#e3f2fd', '#bbdefb', '#90caf9', '#64b5f6', '#42a5f5', '#2196f3', '#1e88e5'];
-    return { background: colors[idx] || '#fff' };
-  }
-  const palette = ['#fff', '#c8e6c9', '#81c784'];
-  return { background: palette[val] || '#fff' };
+  if (!entry) return 0;
+  let total =
+    entry.sleep_before_midnight +
+    entry.sleep_quality +
+    entry.morning_sun +
+    entry.active_exercise +
+    entry.conversation +
+    entry.mood;
+  total += entry.alcohol === 0 ? 1 : 0;
+  return total;
 };
 
-const displayValue = (key, date) => {
-  const entry = records.value.find(r => r.date === date);
-  return entry ? entry[key] : '';
+const totalCellStyle = (date) => {
+  const total = totalPoints(date);
+  const colors = ['#fff', '#e0f2f1', '#b2dfdb', '#80cbc4', '#4db6ac', '#26a69a', '#009688', '#00897b', '#00796b', '#00695c'];
+  return { background: colors[total] || '#004d40' };
 };
 
 const ratioData = (key) => {


### PR DESCRIPTION
## Summary
- Replace wellbeing form fields with horizontal button toggles
- Show daily score heatmap based on total points

## Testing
- `npm test` (fails: Missing script "test")
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b16ff0c664832ba1c45239e54feded